### PR TITLE
DBC Naming Pattern fixed

### DIFF
--- a/ida/tutil.py
+++ b/ida/tutil.py
@@ -12,8 +12,7 @@ def _add_type (name, decl, attr, pre, post, mode):
     if mode == ADD_TYPE.ENSURE_UNIQUE:
       raise RuntimeError ("struct %s already exists" % (name))
     elif mode == ADD_TYPE.REPLACE:
-      print ("## removed existing", name)
-      ida_typeinf.del_named_type (cvar.idati, name, ida_typeinf.NTF_TYPE)
+      print ("## replaced existing", name)
     elif mode == ADD_TYPE.KEEP:
       print ("## kept existing", name)
       return name


### PR DESCRIPTION
- "Fix" issue where types got removed and re-added, resulting in a lot of empty entries in Local Types window
- Fix issue where the build string was prefixed with `b'<build>'` resulting in columns not being retrieved.
- Fix issue where `Name` is deprecated and replaced with `idc.get_name`
- Fix issue where `make_column_getter_name` get's a float argument instead of int (blame IDA)